### PR TITLE
chore: add missing shared CI workflows

### DIFF
--- a/.github/workflows/locale_check.yml
+++ b/.github/workflows/locale_check.yml
@@ -1,0 +1,13 @@
+name: Locale Build Check
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  locale_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/locale-check.yml@dev
+    secrets: inherit
+    with:
+      pr_comment: true


### PR DESCRIPTION
Adds the missing canonical OVOS shared reusable-workflow caller (referencing `OpenVoiceOS/gh-automations/.github/workflows/*@dev`).

Added:
- locale-check (skill ships a `locale/` folder)

All other canonical callers (build-tests, coverage, lint, license-check, pip-audit, repo-health, release-preview, publish-alpha, publish-stable, conventional-label, skill-check, ovoscope) were already present and `@dev` on `dev`.
