### PR TITLE
fix(da-DK): remove spaces inside placeholder braces, restore {digits} name

### DIFF
--- a/locale/da-DK/last_digits.dialog
+++ b/locale/da-DK/last_digits.dialog
@@ -1,5 +1,5 @@
-Min I.P. adresse slutter med { digits }
-Min I.P. adresse slutter med { digits }
-Min I.P. slutter med { digits }
-Min I.P. slutter med { digits }
-det ender med { digits }
+Min I.P. adresse slutter med {digits}
+Min I.P. adresse slutter med {digits}
+Min I.P. slutter med {digits}
+Min I.P. slutter med {digits}
+det ender med {digits}

--- a/locale/da-DK/last_digits_device.dialog
+++ b/locale/da-DK/last_digits_device.dialog
@@ -1,5 +1,5 @@
-På { device } min I.P. adresse slutter med { cifre }
-På { device } min I.P. adresse slutter med { digits }
-På { device } min I.P. slutter med { digits }
-På { device } min I.P. slutter med { digits }
-På { device } slutter det med { digits }
+På {device} min I.P. adresse slutter med {digits}
+På {device} min I.P. adresse slutter med {digits}
+På {device} min I.P. slutter med {digits}
+På {device} min I.P. slutter med {digits}
+På {device} slutter det med {digits}


### PR DESCRIPTION
Found via ovos-localize validation while doing a general da-DK translation review.

Both dialog files used `{ digits }` and `{ device }` (with spaces inside the braces) instead of `{digits}`/`{device}` - `.format()` does not strip whitespace inside braces, so this would not actually substitute at runtime, leaving the literal placeholder in the spoken output instead of the real value.

`last_digits_device.dialog` also had one line with `{ cifre }` - cifre is Danish for digits, but the placeholder name itself must match the English source exactly.